### PR TITLE
[Mina graphql client] Expand itn graphql requests

### DIFF
--- a/internal-log-fetcher/mina-graphql-client/Cargo.lock
+++ b/internal-log-fetcher/mina-graphql-client/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "futures-util",
  "graphql_client",
  "httpmock",
+ "log",
  "object_store",
  "rand 0.7.3",
  "reqwest",

--- a/internal-log-fetcher/mina-graphql-client/Cargo.toml
+++ b/internal-log-fetcher/mina-graphql-client/Cargo.toml
@@ -29,8 +29,10 @@ structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+log = "0.4"
 warp = "0.3"
 url = "2.5.4"
+
 
 
 [dev-dependencies]

--- a/internal-log-fetcher/mina-graphql-client/examples/generate_keypair.rs
+++ b/internal-log-fetcher/mina-graphql-client/examples/generate_keypair.rs
@@ -4,8 +4,7 @@ use rand::rngs::OsRng;
 
 fn main() {
     // Generate a new random secret key
-    let mut csprng = OsRng {};
-    let secret_key = SecretKey::generate(&mut csprng);
+    let secret_key = SecretKey::generate(&mut OsRng);
 
     // Derive the public key
     let public_key: PublicKey = (&secret_key).into();
@@ -14,10 +13,14 @@ fn main() {
     let private_key_b64 = encode(secret_key.as_bytes());
     let public_key_b64 = encode(public_key.as_bytes());
 
-    println!("Generated Ed25519 Keypair:");
-    println!("==========================");
-    println!("Private key: {}", private_key_b64);
-    println!("Public key:  {}", public_key_b64);
-    println!();
-    println!("Keep your private key secret!");
+    println!(
+        r#"
+Generated Ed25519 Keypair:
+==========================
+Private key: {private_key_b64}
+Public key:  {public_key_b64}
+
+Keep your private key secret!
+"#
+    );
 }

--- a/internal-log-fetcher/mina-graphql-client/examples/generate_keypair.rs
+++ b/internal-log-fetcher/mina-graphql-client/examples/generate_keypair.rs
@@ -1,0 +1,23 @@
+use base64::encode;
+use ed25519_dalek::{PublicKey, SecretKey};
+use rand::rngs::OsRng;
+
+fn main() {
+    // Generate a new random secret key
+    let mut csprng = OsRng {};
+    let secret_key = SecretKey::generate(&mut csprng);
+
+    // Derive the public key
+    let public_key: PublicKey = (&secret_key).into();
+
+    // Encode both to base64
+    let private_key_b64 = encode(secret_key.as_bytes());
+    let public_key_b64 = encode(public_key.as_bytes());
+
+    println!("Generated Ed25519 Keypair:");
+    println!("==========================");
+    println!("Private key: {}", private_key_b64);
+    println!("Public key:  {}", public_key_b64);
+    println!();
+    println!("Keep your private key secret!");
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/connection_gating_config.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/connection_gating_config.graphql
@@ -1,0 +1,15 @@
+query ConnectionGatingConfigQuery {
+    connectionGatingConfig {
+        trustedPeers {
+            peerId
+            host
+            libp2pPort
+        }
+        bannedPeers {
+            peerId
+            host
+            libp2pPort
+        }
+        isolate
+    }
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/get_peers.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/get_peers.graphql
@@ -1,0 +1,7 @@
+query GetPeersQuery {
+    getPeers {
+        peerId
+        host
+        libp2pPort
+    }
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/schedule_payments.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/schedule_payments.graphql
@@ -1,0 +1,3 @@
+mutation SchedulePaymentsQuery ($input: PaymentsDetails!) {
+    schedulePayments(input: $input)
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/schema.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/schema.graphql
@@ -112,6 +112,14 @@ type mutation {
   zkAppCommandLimit(
     limit: [Int]
   ): String!
+
+  """Stop the Mina daemon"""
+  stopDaemon(
+    """Seconds to delay before stopping daemon (minimum 5)"""
+    delaySeconds: Int
+    """Whether to remove saved configuration data (default false)"""
+    cleanConfig: Boolean
+  ): String!
 }
 
 """Network identifiers for another protocol participant"""
@@ -204,7 +212,37 @@ type query {
     """Least log ID to start with"""
     startLogId: Int!
   ): [ItnLog!]!
+
+  """The rules that the libp2p helper will use to determine which connections to permit"""
+  connectionGatingConfig: ConnectionGatingConfig!
+
+  """List of peers that the daemon is currently connected to"""
+  getPeers: [Peer!]!
 }
 
 """String representing a uint16 number in base 10"""
 scalar UInt16
+
+"""Peer information"""
+type Peer {
+  """base58-encoded peer ID"""
+  peerId: String!
+
+  """IP address of the peer"""
+  host: String!
+
+  """libp2p port of the peer"""
+  libp2pPort: Int!
+}
+
+"""Connection gating configuration"""
+type ConnectionGatingConfig {
+  """Peers we will always allow connections from"""
+  trustedPeers: [Peer!]!
+
+  """Peers we will never allow connections from (unless they are also trusted!)"""
+  bannedPeers: [Peer!]!
+
+  """If true, no connections will be allowed unless they are from a trusted peer"""
+  isolate: Boolean!
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/slots_won_query.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/slots_won_query.graphql
@@ -1,0 +1,3 @@
+query SlotsWonQuery {
+    slotsWon
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/stop_daemon.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/stop_daemon.graphql
@@ -1,0 +1,3 @@
+mutation StopDaemonQuery($delaySeconds: Int, $cleanConfig: Boolean) {
+    stopDaemon(delaySeconds: $delaySeconds, cleanConfig: $cleanConfig)
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/stop_payments.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/stop_payments.graphql
@@ -1,0 +1,3 @@
+mutation StopPaymentsQuery ($handle: String!) {
+    stopPayments(handle: $handle)
+}

--- a/internal-log-fetcher/mina-graphql-client/graphql/update_gating.graphql
+++ b/internal-log-fetcher/mina-graphql-client/graphql/update_gating.graphql
@@ -1,0 +1,3 @@
+mutation UpdateGatingQuery ($input: GatingUpdate!) {
+    updateGating(input: $input)
+}

--- a/internal-log-fetcher/mina-graphql-client/src/authentication.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/authentication.rs
@@ -14,7 +14,7 @@ pub(crate) struct BasicAuthenticator {}
 
 pub(crate) struct SequentialAuthenticator {}
 
-pub(crate) struct NoAuthenticator {}
+pub(crate) struct FakeAuthenticator {}
 
 pub(crate) fn sign_data(keypair: &ed25519_dalek::Keypair, data: &[u8]) -> Vec<u8> {
     let signature = keypair.sign(data);
@@ -55,22 +55,25 @@ impl Authenticator for SequentialAuthenticator {
     }
 }
 
-impl Authenticator for NoAuthenticator {
+/// This is a fake authenticator used for testing purposes only.
+/// It does not perform any actual authentication or signing.
+/// Using this in production will result in authentication failures.
+impl Authenticator for FakeAuthenticator {
     fn signature_header(_server: &MinaGraphQLClient, _body_bytes: &[u8]) -> Result<String> {
-        Ok(String::new())
+        Ok(String::from("This is fake authenticator"))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mina_server::{AuthorizationInfo, MinaServer};
+    use crate::mina_client::{AuthorizationInfo, MinaGraphQLClient as MinaServer};
 
     const TEST_SECRET_KEY_BASE64: &str = "SzhpFfwa6RMFQTLLTyoriUJrUXYY9kyYxbNu5DsCm1k=";
     const TEST_PUBLIC_KEY_BASE64: &str = "BaG9HYTNxkqyX7haFnz/HXL9FhYwS4gdQ7uYWiStgoY=";
     const TEST_SERVER_UUID: &str = "24511be6-320d-4ef2-8dff-89916bcb6751";
 
-    // Helper function to create a MinaServer instance for testing
+    // Helper function to create a MinaGraphQLClient instance for testing
     fn create_test_server() -> MinaServer {
         let sk_bytes = general_purpose::STANDARD
             .decode(TEST_SECRET_KEY_BASE64)
@@ -84,18 +87,19 @@ mod tests {
             public: public_key,
         };
         MinaServer {
+            config: crate::mina_client::MinaClientConfig {
+                address: "localhost".to_string(),
+                graphql_port: 3085,
+                use_https: false,
+                secret_key_base64: TEST_SECRET_KEY_BASE64.to_string(),
+            },
             pk_base64: TEST_PUBLIC_KEY_BASE64.to_string(),
             keypair,
+            last_log_id: 1,
             authorization_info: Some(AuthorizationInfo {
                 server_uuid: TEST_SERVER_UUID.to_string(),
                 signer_sequence_number: 1,
             }),
-            graphql_uri: "http://localhost".to_string(),
-            last_log_id: 1,
-            output_dir_path: "/tmp".into(),
-            main_trace_file: None,
-            verifier_trace_file: None,
-            prover_trace_file: None,
         }
     }
 

--- a/internal-log-fetcher/mina-graphql-client/src/authentication.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/authentication.rs
@@ -14,6 +14,8 @@ pub(crate) struct BasicAuthenticator {}
 
 pub(crate) struct SequentialAuthenticator {}
 
+pub(crate) struct NoAuthenticator {}
+
 pub(crate) fn sign_data(keypair: &ed25519_dalek::Keypair, data: &[u8]) -> Vec<u8> {
     let signature = keypair.sign(data);
     let signature_bytes = signature.to_bytes();
@@ -50,6 +52,12 @@ impl Authenticator for SequentialAuthenticator {
         let pk_base64 = &server.pk_base64;
 
         Ok(format!("Signature {pk_base64} {signature_base64} ; Sequencing {server_uuid} {signer_sequence_number}"))
+    }
+}
+
+impl Authenticator for NoAuthenticator {
+    fn signature_header(_server: &MinaGraphQLClient, _body_bytes: &[u8]) -> Result<String> {
+        Ok(String::new())
     }
 }
 

--- a/internal-log-fetcher/mina-graphql-client/src/graphql.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/graphql.rs
@@ -5,12 +5,17 @@ use graphql_client::GraphQLQuery;
 
 pub(crate) type Json = serde_json::Value;
 pub(crate) type UInt16 = String;
+pub(crate) type CurrencyAmount = String;
+pub(crate) type Fee = String;
+pub(crate) type PrivateKey = String;
+pub(crate) type PublicKey = String;
 
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "graphql/schema.graphql",
     query_path = "graphql/internal_logs_query.graphql",
-    response_derives = "Debug"
+    response_derives = "Debug",
+    variables_derives = "Debug"
 )]
 pub struct InternalLogsQuery;
 
@@ -18,7 +23,8 @@ pub struct InternalLogsQuery;
 #[graphql(
     schema_path = "graphql/schema.graphql",
     query_path = "graphql/flush_internal_logs_mutation.graphql",
-    response_derives = "Debug"
+    response_derives = "Debug",
+    variables_derives = "Debug"
 )]
 pub struct FlushInternalLogsQuery;
 
@@ -26,7 +32,8 @@ pub struct FlushInternalLogsQuery;
 #[graphql(
     schema_path = "graphql/schema.graphql",
     query_path = "graphql/auth_query.graphql",
-    response_derives = "Debug"
+    response_derives = "Debug",
+    variables_derives = "Debug"
 )]
 pub struct AuthQuery;
 
@@ -34,7 +41,8 @@ pub struct AuthQuery;
 #[graphql(
     schema_path = "graphql/schema.graphql",
     query_path = "graphql/reset_zkapp_soft_limit.graphql",
-    response_derives = "Debug"
+    response_derives = "Debug",
+    variables_derives = "Debug"
 )]
 pub struct ResetZkappSoftLimitQuery;
 
@@ -42,6 +50,70 @@ pub struct ResetZkappSoftLimitQuery;
 #[graphql(
     schema_path = "graphql/schema.graphql",
     query_path = "graphql/schedule_zkapp_commands.graphql",
-    response_derives = "Debug"
+    response_derives = "Debug",
+    variables_derives = "Debug"
 )]
 pub struct ScheduleZkappCommandsQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/schedule_payments.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug"
+)]
+pub struct SchedulePaymentsQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/stop_payments.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug"
+)]
+pub struct StopPaymentsQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/update_gating.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug"
+)]
+pub struct UpdateGatingQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/slots_won_query.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug"
+)]
+pub struct SlotsWonQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/stop_daemon.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug"
+)]
+pub struct StopDaemonQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/connection_gating_config.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug"
+)]
+pub struct ConnectionGatingConfigQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/get_peers.graphql",
+    response_derives = "Debug",
+    variables_derives = "Debug"
+)]
+pub struct GetPeersQuery;

--- a/internal-log-fetcher/mina-graphql-client/src/lib.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/lib.rs
@@ -3,5 +3,7 @@ mod graphql;
 mod mina_client;
 
 pub use graphql::internal_logs_query::InternalLogsQueryInternalLogs;
+pub use graphql::schedule_payments_query::PaymentsDetails;
 pub use graphql::schedule_zkapp_commands_query::ZkappCommandsDetails;
+pub use graphql::update_gating_query::{GatingUpdate, NetworkPeer};
 pub use mina_client::{MinaClientConfig, MinaGraphQLClient};

--- a/internal-log-fetcher/mina-graphql-client/src/main.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/main.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
+use log::info;
 use mina_graphql_client::{
     GatingUpdate, MinaClientConfig, MinaGraphQLClient, NetworkPeer, PaymentsDetails,
     ZkappCommandsDetails,
 };
+use serde::Serialize;
 use structopt::StructOpt;
 use url::Url;
 
@@ -19,6 +21,10 @@ struct Cli {
     #[structopt(name = "address", env = "ADDRESS")]
     /// Address in format `host:port` of the graphql server.
     address: String,
+
+    #[structopt(long, short = "j")]
+    /// Output results in JSON format for programmatic use
+    json: bool,
 
     #[structopt(subcommand, about = "The command to run.")]
     cmd: Command,
@@ -190,27 +196,29 @@ fn parse_network_peer(s: &str) -> Result<NetworkPeer> {
     })
 }
 
-impl InputGatingUpdate {
-    fn into_gating_update(self) -> Result<GatingUpdate> {
-        let added_peers: Result<Vec<NetworkPeer>> = self
+impl std::convert::TryFrom<InputGatingUpdate> for GatingUpdate {
+    type Error = anyhow::Error;
+
+    fn try_from(value: InputGatingUpdate) -> Result<Self, Self::Error> {
+        let added_peers: Result<Vec<NetworkPeer>> = value
             .added_peers
             .iter()
             .map(|s| parse_network_peer(s))
             .collect();
-        let banned_peers: Result<Vec<NetworkPeer>> = self
+        let banned_peers: Result<Vec<NetworkPeer>> = value
             .banned_peers
             .iter()
             .map(|s| parse_network_peer(s))
             .collect();
-        let trusted_peers: Result<Vec<NetworkPeer>> = self
+        let trusted_peers: Result<Vec<NetworkPeer>> = value
             .trusted_peers
             .iter()
             .map(|s| parse_network_peer(s))
             .collect();
 
         Ok(GatingUpdate {
-            clean_added_peers: self.clean_added_peers,
-            isolate: self.isolate,
+            clean_added_peers: value.clean_added_peers,
+            isolate: value.isolate,
             added_peers: added_peers?,
             banned_peers: banned_peers?,
             trusted_peers: trusted_peers?,
@@ -254,6 +262,44 @@ enum Command {
     GetPeers,
 }
 
+/// Output structures for JSON serialization
+#[derive(Debug, Serialize)]
+struct PeerOutput {
+    peer_id: String,
+    host: String,
+    libp2p_port: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct ConnectionGatingOutput {
+    isolate: bool,
+    trusted_peers: Vec<PeerOutput>,
+    banned_peers: Vec<PeerOutput>,
+}
+
+#[derive(Debug, Serialize)]
+struct FetchLogsOutput {
+    new_logs_available: bool,
+    logs_count: usize,
+    logs: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GenericOutput {
+    result: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SlotsWonOutput {
+    slots: Vec<i64>,
+}
+
+/// Helper function to output data in JSON or human-readable format
+fn output_json<T: Serialize>(data: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(data)?);
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
@@ -277,89 +323,146 @@ async fn main() -> Result<()> {
     match opt.cmd {
         Command::Auth => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
         }
         Command::FetchMoreLogs => {
             client.authorize().await?;
-            println!("authorized");
-            let (last_log_id, logs) = client.fetch_more_logs().await?;
-            println!("last log id: {}", last_log_id);
-            println!("logs: {:#?}", logs);
+            info!("authorized");
+            let (new_logs_available, logs) = client.fetch_more_logs().await?;
+            if opt.json {
+                output_json(&FetchLogsOutput {
+                    new_logs_available,
+                    logs_count: logs.len(),
+                    logs: format!("{:#?}", logs),
+                })?;
+            } else {
+                println!("new logs available: {}", new_logs_available);
+                println!("logs: {:#?}", logs);
+            }
         }
         Command::FlushLogs => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
             client.flush_logs().await?;
-            println!("flushed logs");
+            info!("flushed logs");
         }
         Command::ResetZkappSoftLimit => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
             client.reset_zkapp_soft_limit_query().await?;
+            info!("reset zkapp soft limit");
         }
         Command::ScheduleZkappPayments(cmd) => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
             client.schedule_zkapp_payments(cmd.into()).await?;
+            info!("scheduled zkapp payments");
         }
         Command::SchedulePayments(cmd) => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
             let handle = client.schedule_payments(cmd.into()).await?;
-            println!("Scheduled payments with handle: {}", handle);
+            if opt.json {
+                output_json(&GenericOutput {
+                    result: handle,
+                })?;
+            } else {
+                println!("Scheduled payments with handle: {}", handle);
+            }
         }
         Command::StopPayments { handle } => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
             let result = client.stop_payments(handle).await?;
-            println!("Stop payments result: {}", result);
+            if opt.json {
+                output_json(&GenericOutput { result })?;
+            } else {
+                println!("Stop payments result: {}", result);
+            }
         }
         Command::UpdateGating(cmd) => {
             client.authorize().await?;
-            println!("authorized");
-            let gating_update = cmd.into_gating_update()?;
+            info!("authorized");
+            let gating_update: GatingUpdate = cmd.try_into()?;
             let result = client.update_gating(gating_update).await?;
-            println!("Update gating result: {}", result);
+            if opt.json {
+                output_json(&GenericOutput { result })?;
+            } else {
+                println!("Update gating result: {}", result);
+            }
         }
         Command::SlotsWon => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
             let slots = client.slots_won().await?;
-            println!("Slots won: {:?}", slots);
+            if opt.json {
+                output_json(&SlotsWonOutput { slots })?;
+            } else {
+                println!("Slots won: {:?}", slots);
+            }
         }
         Command::StopDaemon {
             delay_seconds,
             clean_config,
         } => {
             client.authorize().await?;
-            println!("authorized");
+            info!("authorized");
             let clean_config_opt = if clean_config { Some(true) } else { None };
             let result = client.stop_daemon(delay_seconds, clean_config_opt).await?;
-            println!("Stop daemon result: {}", result);
+            if opt.json {
+                output_json(&GenericOutput { result })?;
+            } else {
+                println!("Stop daemon result: {}", result);
+            }
         }
         Command::ConnectionGatingConfig => {
             let config = client.connection_gating_config().await?;
-            println!("\nConnection Gating Configuration:");
-            println!("================================");
-            println!("Isolate mode: {}", config.isolate);
-            println!("\nTrusted Peers ({}):", config.trusted_peers.len());
-            for peer in &config.trusted_peers {
-                println!("  - {} ({}:{})", peer.peer_id, peer.host, peer.libp2p_port);
-            }
-            println!("\nBanned Peers ({}):", config.banned_peers.len());
-            for peer in &config.banned_peers {
-                println!("  - {} ({}:{})", peer.peer_id, peer.host, peer.libp2p_port);
+            if opt.json {
+                output_json(&ConnectionGatingOutput {
+                    isolate: config.isolate,
+                    trusted_peers: config.trusted_peers.iter().map(|p| PeerOutput {
+                        peer_id: p.peer_id.clone(),
+                        host: p.host.clone(),
+                        libp2p_port: p.libp2p_port,
+                    }).collect(),
+                    banned_peers: config.banned_peers.iter().map(|p| PeerOutput {
+                        peer_id: p.peer_id.clone(),
+                        host: p.host.clone(),
+                        libp2p_port: p.libp2p_port,
+                    }).collect(),
+                })?;
+            } else {
+                println!("\nConnection Gating Configuration:");
+                println!("================================");
+                println!("Isolate mode: {}", config.isolate);
+                println!("\nTrusted Peers ({}):", config.trusted_peers.len());
+                for peer in &config.trusted_peers {
+                    println!("  - {} ({}:{})", peer.peer_id, peer.host, peer.libp2p_port);
+                }
+                println!("\nBanned Peers ({}):", config.banned_peers.len());
+                for peer in &config.banned_peers {
+                    println!("  - {} ({}:{})", peer.peer_id, peer.host, peer.libp2p_port);
+                }
             }
         }
         Command::GetPeers => {
             let peers = client.get_peers().await?;
-            println!("\nConnected Peers ({}):", peers.len());
-            println!("===================");
-            for peer in &peers {
-                println!("Peer ID:      {}", peer.peer_id);
-                println!("Host:         {}", peer.host);
-                println!("Libp2p Port:  {}", peer.libp2p_port);
-                println!("---");
+            if opt.json {
+                let peer_outputs: Vec<PeerOutput> = peers.iter().map(|p| PeerOutput {
+                    peer_id: p.peer_id.clone(),
+                    host: p.host.clone(),
+                    libp2p_port: p.libp2p_port,
+                }).collect();
+                output_json(&peer_outputs)?;
+            } else {
+                println!("\nConnected Peers ({}):", peers.len());
+                println!("===================");
+                for peer in &peers {
+                    println!("Peer ID:      {}", peer.peer_id);
+                    println!("Host:         {}", peer.host);
+                    println!("Libp2p Port:  {}", peer.libp2p_port);
+                    println!("---");
+                }
             }
         }
     };

--- a/internal-log-fetcher/mina-graphql-client/src/main.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/main.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use mina_graphql_client::{MinaClientConfig, MinaGraphQLClient, ZkappCommandsDetails};
+use mina_graphql_client::{
+    GatingUpdate, MinaClientConfig, MinaGraphQLClient, NetworkPeer, PaymentsDetails,
+    ZkappCommandsDetails,
+};
 use structopt::StructOpt;
 use url::Url;
 
@@ -66,28 +69,152 @@ struct InputZkappCommandsDetails {
     fee_payers: Vec<String>,
 }
 
-impl Into<ZkappCommandsDetails> for InputZkappCommandsDetails {
-    fn into(self) -> ZkappCommandsDetails {
+impl From<InputZkappCommandsDetails> for ZkappCommandsDetails {
+    fn from(val: InputZkappCommandsDetails) -> Self {
         ZkappCommandsDetails {
-            max_account_updates: self.max_account_updates,
-            max_cost: self.max_cost,
-            account_queue_size: self.account_queue_size,
-            deployment_fee: self.deployment_fee,
-            max_fee: self.max_fee,
-            min_fee: self.min_fee,
-            init_balance: self.init_balance,
-            max_new_zkapp_balance: self.max_new_zkapp_balance,
-            min_new_zkapp_balance: self.min_new_zkapp_balance,
-            max_balance_change: self.max_balance_change,
-            min_balance_change: self.min_balance_change,
-            no_precondition: self.no_precondition,
-            memo_prefix: self.memo_prefix,
-            duration_min: self.duration_min,
-            tps: self.tps,
-            num_new_accounts: self.num_new_accounts,
-            num_zkapps_to_deploy: self.num_zkapps_to_deploy,
-            fee_payers: self.fee_payers,
+            max_account_updates: val.max_account_updates,
+            max_cost: val.max_cost,
+            account_queue_size: val.account_queue_size,
+            deployment_fee: val.deployment_fee,
+            max_fee: val.max_fee,
+            min_fee: val.min_fee,
+            init_balance: val.init_balance,
+            max_new_zkapp_balance: val.max_new_zkapp_balance,
+            min_new_zkapp_balance: val.min_new_zkapp_balance,
+            max_balance_change: val.max_balance_change,
+            min_balance_change: val.min_balance_change,
+            no_precondition: val.no_precondition,
+            memo_prefix: val.memo_prefix,
+            duration_min: val.duration_min,
+            tps: val.tps,
+            num_new_accounts: val.num_new_accounts,
+            num_zkapps_to_deploy: val.num_zkapps_to_deploy,
+            fee_payers: val.fee_payers,
         }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+struct InputPaymentsDetails {
+    #[structopt(long, default_value = "30")]
+    duration_min: i64,
+
+    #[structopt(long, default_value = "0.25")]
+    tps: f64,
+
+    #[structopt(long, default_value = "test")]
+    memo: String,
+
+    #[structopt(long, default_value = "2000000000")]
+    fee_max: String,
+
+    #[structopt(long, default_value = "1000000000")]
+    fee_min: String,
+
+    #[structopt(long, default_value = "1000000000")]
+    amount: String,
+
+    #[structopt(long)]
+    receiver: String,
+
+    #[structopt(long, default_value = "Vec::new()")]
+    senders: Vec<String>,
+}
+
+impl From<InputPaymentsDetails> for PaymentsDetails {
+    fn from(val: InputPaymentsDetails) -> Self {
+        PaymentsDetails {
+            duration_in_minutes: val.duration_min,
+            transactions_per_second: val.tps,
+            memo: val.memo,
+            fee_max: val.fee_max,
+            fee_min: val.fee_min,
+            amount: val.amount,
+            receiver: val.receiver,
+            senders: val.senders,
+        }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+struct InputNetworkPeer {
+    #[structopt(long)]
+    host: String,
+
+    #[structopt(long)]
+    libp2p_port: i64,
+
+    #[structopt(long)]
+    peer_id: String,
+}
+
+impl From<InputNetworkPeer> for NetworkPeer {
+    fn from(val: InputNetworkPeer) -> Self {
+        NetworkPeer {
+            host: val.host,
+            libp2p_port: val.libp2p_port,
+            peer_id: val.peer_id,
+        }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+struct InputGatingUpdate {
+    #[structopt(long)]
+    clean_added_peers: bool,
+
+    #[structopt(long)]
+    isolate: bool,
+
+    #[structopt(long)]
+    added_peers: Vec<String>,
+
+    #[structopt(long)]
+    banned_peers: Vec<String>,
+
+    #[structopt(long)]
+    trusted_peers: Vec<String>,
+}
+
+fn parse_network_peer(s: &str) -> Result<NetworkPeer> {
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() != 3 {
+        return Err(anyhow::anyhow!(
+            "Invalid network peer format. Expected: host,libp2p_port,peer_id"
+        ));
+    }
+    Ok(NetworkPeer {
+        host: parts[0].to_string(),
+        libp2p_port: parts[1].parse()?,
+        peer_id: parts[2].to_string(),
+    })
+}
+
+impl InputGatingUpdate {
+    fn into_gating_update(self) -> Result<GatingUpdate> {
+        let added_peers: Result<Vec<NetworkPeer>> = self
+            .added_peers
+            .iter()
+            .map(|s| parse_network_peer(s))
+            .collect();
+        let banned_peers: Result<Vec<NetworkPeer>> = self
+            .banned_peers
+            .iter()
+            .map(|s| parse_network_peer(s))
+            .collect();
+        let trusted_peers: Result<Vec<NetworkPeer>> = self
+            .trusted_peers
+            .iter()
+            .map(|s| parse_network_peer(s))
+            .collect();
+
+        Ok(GatingUpdate {
+            clean_added_peers: self.clean_added_peers,
+            isolate: self.isolate,
+            added_peers: added_peers?,
+            banned_peers: banned_peers?,
+            trusted_peers: trusted_peers?,
+        })
     }
 }
 
@@ -103,10 +230,34 @@ enum Command {
     ResetZkappSoftLimit,
     /// Schedule zkapp payments.
     ScheduleZkappPayments(InputZkappCommandsDetails),
+    /// Schedule regular payments.
+    SchedulePayments(InputPaymentsDetails),
+    /// Stop scheduled transactions.
+    StopPayments {
+        #[structopt(long)]
+        handle: String,
+    },
+    /// Update gating configuration.
+    UpdateGating(InputGatingUpdate),
+    /// Get slots won by block producer.
+    SlotsWon,
+    /// Stop the Mina daemon.
+    StopDaemon {
+        #[structopt(long)]
+        delay_seconds: Option<i64>,
+        #[structopt(long)]
+        clean_config: bool,
+    },
+    /// Get connection gating configuration (trusted peers, banned peers, isolate mode).
+    ConnectionGatingConfig,
+    /// Get list of currently connected peers.
+    GetPeers,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
     let opt = Cli::from_args();
 
     let error_msg = "Invalid address format, expected http(s)://host:port";
@@ -150,6 +301,66 @@ async fn main() -> Result<()> {
             client.authorize().await?;
             println!("authorized");
             client.schedule_zkapp_payments(cmd.into()).await?;
+        }
+        Command::SchedulePayments(cmd) => {
+            client.authorize().await?;
+            println!("authorized");
+            let handle = client.schedule_payments(cmd.into()).await?;
+            println!("Scheduled payments with handle: {}", handle);
+        }
+        Command::StopPayments { handle } => {
+            client.authorize().await?;
+            println!("authorized");
+            let result = client.stop_payments(handle).await?;
+            println!("Stop payments result: {}", result);
+        }
+        Command::UpdateGating(cmd) => {
+            client.authorize().await?;
+            println!("authorized");
+            let gating_update = cmd.into_gating_update()?;
+            let result = client.update_gating(gating_update).await?;
+            println!("Update gating result: {}", result);
+        }
+        Command::SlotsWon => {
+            client.authorize().await?;
+            println!("authorized");
+            let slots = client.slots_won().await?;
+            println!("Slots won: {:?}", slots);
+        }
+        Command::StopDaemon {
+            delay_seconds,
+            clean_config,
+        } => {
+            client.authorize().await?;
+            println!("authorized");
+            let clean_config_opt = if clean_config { Some(true) } else { None };
+            let result = client.stop_daemon(delay_seconds, clean_config_opt).await?;
+            println!("Stop daemon result: {}", result);
+        }
+        Command::ConnectionGatingConfig => {
+            let config = client.connection_gating_config().await?;
+            println!("\nConnection Gating Configuration:");
+            println!("================================");
+            println!("Isolate mode: {}", config.isolate);
+            println!("\nTrusted Peers ({}):", config.trusted_peers.len());
+            for peer in &config.trusted_peers {
+                println!("  - {} ({}:{})", peer.peer_id, peer.host, peer.libp2p_port);
+            }
+            println!("\nBanned Peers ({}):", config.banned_peers.len());
+            for peer in &config.banned_peers {
+                println!("  - {} ({}:{})", peer.peer_id, peer.host, peer.libp2p_port);
+            }
+        }
+        Command::GetPeers => {
+            let peers = client.get_peers().await?;
+            println!("\nConnected Peers ({}):", peers.len());
+            println!("===================");
+            for peer in &peers {
+                println!("Peer ID:      {}", peer.peer_id);
+                println!("Host:         {}", peer.host);
+                println!("Libp2p Port:  {}", peer.libp2p_port);
+                println!("---");
+            }
         }
     };
 

--- a/internal-log-fetcher/mina-graphql-client/src/mina_client.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/mina_client.rs
@@ -1,6 +1,10 @@
-use crate::authentication::{Authenticator, BasicAuthenticator, SequentialAuthenticator};
+use crate::authentication::{
+    Authenticator, BasicAuthenticator, NoAuthenticator, SequentialAuthenticator,
+};
 use crate::graphql;
+use crate::graphql::schedule_payments_query::PaymentsDetails;
 use crate::graphql::schedule_zkapp_commands_query::ZkappCommandsDetails;
+use crate::graphql::update_gating_query::GatingUpdate;
 use crate::InternalLogsQueryInternalLogs;
 
 use anyhow::{anyhow, Result};
@@ -105,7 +109,7 @@ impl MinaGraphQLClient {
             serde_json::to_vec(query).map_err(|e| anyhow!("Invalid JSON query: {}", e))?;
         let signature_header = SequentialAuthenticator::signature_header(self, &body_bytes)?;
         let response = client
-            .post(&self.config.graphql_uri())
+            .post(self.config.graphql_uri())
             .json(&query)
             .header(reqwest::header::AUTHORIZATION, signature_header)
             .header(
@@ -128,20 +132,27 @@ impl MinaGraphQLClient {
         &self,
         client: &reqwest::Client,
         variables: Q::Variables,
-    ) -> Result<graphql_client::Response<Q::ResponseData>> {
+    ) -> Result<graphql_client::Response<Q::ResponseData>>
+    where
+        Q::Variables: std::fmt::Debug,
+    {
         let body = Q::build_query(variables);
         let body_bytes = serde_json::to_vec(&body)?;
         let signature_header = A::signature_header(self, &body_bytes)?;
         let response = client
-            .post(&self.config.graphql_uri())
+            .post(self.config.graphql_uri())
             .json(&body)
-            .header(reqwest::header::AUTHORIZATION, signature_header)
-            .send()
-            .await?;
+            .header(reqwest::header::AUTHORIZATION, signature_header);
+        tracing::debug!("GraphQL request body: {:#?}", &body);
+        let response = response.send().await?;
 
         tracing::debug!("GraphQL response: {:#?}", response);
 
-        Ok(response.json().await?)
+        let response_text = response.text().await?;
+        tracing::debug!("GraphQL response body: {}", response_text);
+
+        let parsed_response = serde_json::from_str(&response_text)?;
+        Ok(parsed_response)
     }
 
     pub async fn reset_zkapp_soft_limit_query(&self) -> Result<()> {
@@ -214,5 +225,127 @@ impl MinaGraphQLClient {
             .await?;
         let _response_data = response.data.unwrap();
         Ok(())
+    }
+
+    pub async fn schedule_payments(&self, input: PaymentsDetails) -> Result<String> {
+        let client = reqwest::Client::new();
+        let variables = graphql::schedule_payments_query::Variables { input };
+        let response = self
+            .post_graphql::<graphql::SchedulePaymentsQuery, BasicAuthenticator>(&client, variables)
+            .await?;
+        let handle = response
+            .data
+            .ok_or_else(|| anyhow!("Response data is missing"))?
+            .schedule_payments;
+        Ok(handle)
+    }
+
+    pub async fn stop_payments(&self, handle: String) -> Result<String> {
+        let client = reqwest::Client::new();
+        let variables = graphql::stop_payments_query::Variables { handle };
+        let response = self
+            .post_graphql::<graphql::StopPaymentsQuery, BasicAuthenticator>(&client, variables)
+            .await?;
+        let result = response
+            .data
+            .ok_or_else(|| anyhow!("Response data is missing"))?
+            .stop_payments;
+        Ok(result)
+    }
+
+    pub async fn update_gating(&self, input: GatingUpdate) -> Result<String> {
+        let client = reqwest::Client::new();
+        let variables = graphql::update_gating_query::Variables { input };
+        let response = self
+            .post_graphql::<graphql::UpdateGatingQuery, SequentialAuthenticator>(&client, variables)
+            .await?;
+
+        if let Some(errors) = response.errors {
+            tracing::error!("GraphQL errors: {:?}", errors);
+            return Err(anyhow!("GraphQL errors: {:?}", errors));
+        }
+
+        let result = response
+            .data
+            .ok_or_else(|| anyhow!("Response data is missing"))?
+            .update_gating;
+        Ok(result)
+    }
+
+    pub async fn slots_won(&self) -> Result<Vec<i64>> {
+        let client = reqwest::Client::new();
+        let variables = graphql::slots_won_query::Variables {};
+        let response = self
+            .post_graphql::<graphql::SlotsWonQuery, SequentialAuthenticator>(&client, variables)
+            .await?;
+        let slots = response
+            .data
+            .ok_or_else(|| anyhow!("Response data is missing"))?
+            .slots_won;
+        Ok(slots)
+    }
+
+    pub async fn stop_daemon(
+        &self,
+        delay_seconds: Option<i64>,
+        clean_config: Option<bool>,
+    ) -> Result<String> {
+        let client = reqwest::Client::new();
+        let variables = graphql::stop_daemon_query::Variables {
+            delay_seconds,
+            clean_config,
+        };
+        let response = self
+            .post_graphql::<graphql::StopDaemonQuery, SequentialAuthenticator>(&client, variables)
+            .await?;
+        let result = response
+            .data
+            .ok_or_else(|| anyhow!("Response data is missing"))?
+            .stop_daemon;
+        Ok(result)
+    }
+
+    pub async fn connection_gating_config(
+        &self,
+    ) -> Result<
+        graphql::connection_gating_config_query::ConnectionGatingConfigQueryConnectionGatingConfig,
+    > {
+        let client = reqwest::Client::new();
+        let variables = graphql::connection_gating_config_query::Variables {};
+        let response = self
+            .post_graphql::<graphql::ConnectionGatingConfigQuery, NoAuthenticator>(
+                &client, variables,
+            )
+            .await?;
+
+        if let Some(errors) = response.errors {
+            tracing::error!("GraphQL errors: {:?}", errors);
+            return Err(anyhow!("GraphQL errors: {:?}", errors));
+        }
+
+        let config = response
+            .data
+            .ok_or_else(|| anyhow!("Response data is missing"))?
+            .connection_gating_config;
+        Ok(config)
+    }
+
+    pub async fn get_peers(&self) -> Result<Vec<graphql::get_peers_query::GetPeersQueryGetPeers>> {
+        let client = reqwest::Client::new();
+        let variables = graphql::get_peers_query::Variables {};
+        let response = self
+            .post_graphql::<graphql::GetPeersQuery, NoAuthenticator>(&client, variables)
+            .await?;
+
+        if let Some(errors) = response.errors {
+            tracing::error!("GraphQL errors: {:?}", errors);
+            return Err(anyhow!("GraphQL errors: {:?}", errors));
+        }
+
+        let peers = response
+            .data
+            .ok_or_else(|| anyhow!("Response data is missing"))?
+            .get_peers;
+        Ok(peers)
     }
 }

--- a/internal-log-fetcher/mina-graphql-client/src/mina_client.rs
+++ b/internal-log-fetcher/mina-graphql-client/src/mina_client.rs
@@ -1,5 +1,5 @@
 use crate::authentication::{
-    Authenticator, BasicAuthenticator, NoAuthenticator, SequentialAuthenticator,
+    Authenticator, BasicAuthenticator, FakeAuthenticator, SequentialAuthenticator,
 };
 use crate::graphql;
 use crate::graphql::schedule_payments_query::PaymentsDetails;
@@ -313,7 +313,7 @@ impl MinaGraphQLClient {
         let client = reqwest::Client::new();
         let variables = graphql::connection_gating_config_query::Variables {};
         let response = self
-            .post_graphql::<graphql::ConnectionGatingConfigQuery, NoAuthenticator>(
+            .post_graphql::<graphql::ConnectionGatingConfigQuery, FakeAuthenticator>(
                 &client, variables,
             )
             .await?;
@@ -334,7 +334,7 @@ impl MinaGraphQLClient {
         let client = reqwest::Client::new();
         let variables = graphql::get_peers_query::Variables {};
         let response = self
-            .post_graphql::<graphql::GetPeersQuery, NoAuthenticator>(&client, variables)
+            .post_graphql::<graphql::GetPeersQuery, FakeAuthenticator>(&client, variables)
             .await?;
 
         if let Some(errors) = response.errors {


### PR DESCRIPTION
Mina graphql become an nice tool for debugging graphql send to nodes on occasion to fetch internal logs. My idea is that we can add more requests there since it already handled authentication for itn graphql endpoint. 

I added stop-deamon , update-gating command which are very useful for sending mentioned request to arbitrary node.This can be very handy if we want to perform destructive scenario for post hf network tests. We might not have sufficient time to implement fully automated test to control such scenario. Therefore manually sending requests from cli (or simple bash with timer ) can be sufficient