### PR TITLE
Set max_size:50 for database connection pool

### DIFF
--- a/src/internal_trace_consumer.ml
+++ b/src/internal_trace_consumer.ml
@@ -446,7 +446,7 @@ let add_filename_prefix original_path ~prefix =
   concat (dirname original_path) (prefix ^ basename original_path)
 
 let open_database_or_fail db_uri =
-  match Caqti_async.connect_pool db_uri with
+  match Caqti_async.connect_pool ~max_size:50 db_uri with
   | Error error ->
       Async.Log.Global.error "Failure when opening database: %s"
         (Caqti_error.show error) ;

--- a/src/internal_trace_consumer.ml
+++ b/src/internal_trace_consumer.ml
@@ -446,7 +446,8 @@ let add_filename_prefix original_path ~prefix =
   concat (dirname original_path) (prefix ^ basename original_path)
 
 let open_database_or_fail db_uri =
-  match Caqti_async.connect_pool ~max_size:50 db_uri with
+  let pool_config = Caqti_pool_config.(create () |> set max_size 50) in
+  match Caqti_async.connect_pool ~pool_config db_uri with
   | Error error ->
       Async.Log.Global.error "Failure when opening database: %s"
         (Caqti_error.show error) ;


### PR DESCRIPTION
## Summary
- Sets `~max_size:50` on the `Caqti_async.connect_pool` call in `open_database_or_fail`, limiting the DB connection pool to 50 connections.

## Test plan
- [ ] Deploy and verify the service connects to the database without exhausting connections under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)