### PR TITLE
Skip discovered nodes missing GraphQL port

### DIFF
--- a/internal-log-fetcher/src/discovery.rs
+++ b/internal-log-fetcher/src/discovery.rs
@@ -18,7 +18,7 @@ use crate::node::NodeIdentity;
 struct MetaToBeSaved {
     remote_addr: String,
     submitter: String,
-    graphql_control_port: u16,
+    graphql_control_port: Option<u16>,
 }
 
 struct AwsConfig {
@@ -114,9 +114,17 @@ pub async fn fetch_online(
     let mut results = HashSet::new();
 
     for meta in meta_array {
+        let Some(graphql_control_port) = meta.graphql_control_port else {
+            warn!(
+                "Skipping discovered node {} because graphql_control_port is missing",
+                meta.remote_addr
+            );
+            continue;
+        };
+
         let node = new_node_identity(
             &meta.remote_addr,
-            meta.graphql_control_port,
+            graphql_control_port,
             meta.submitter.clone(),
             host_overrides,
         );
@@ -173,9 +181,17 @@ async fn discover_aws(
     });
 
     for (_, meta) in aws_results {
+        let Some(graphql_control_port) = meta.graphql_control_port else {
+            warn!(
+                "Skipping discovered node {} because graphql_control_port is missing",
+                meta.remote_addr
+            );
+            continue;
+        };
+
         let node = new_node_identity(
             &meta.remote_addr,
-            meta.graphql_control_port,
+            graphql_control_port,
             meta.submitter.clone(),
             host_overrides,
         );

--- a/internal-log-fetcher/src/main.rs
+++ b/internal-log-fetcher/src/main.rs
@@ -519,6 +519,10 @@ mod tests {
                 "remote_addr": "10.233.88.128",
                 "submitter": "B62qjRMUQStdTQwkBLqAXVL3XKSZJCS3g5JGwKnMtszjnBwZhQHqwcz",
                 "graphql_control_port": 20001
+            },
+            {
+                "remote_addr": "10.233.90.128",
+                "submitter": "B62qmissingGraphqlControlPort"
             }
         ]
         "#;


### PR DESCRIPTION
## Summary
- tolerate missing graphql_control_port in discovery metadata
- skip only the malformed discovery entry and keep the rest of the node list
- add a regression fixture for the online discovery response

## Verification
- docker build . -t gcr.io/o1labs-192920/mina-perf-testing/internal-trace-consumer:2.0.3-6145b94